### PR TITLE
fix: externalize reflect-metadata to prevent decorator conflicts #5

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,22 +63,25 @@ await user.save();
 install using `npm`
 
 ```bash
-npm install dynamoose-decorator dynamoose
+npm install dynamoose-decorator dynamoose reflect-metadata
 ```
 
 install using `yarn`
 
 ```bash
-yarn add dynamoose-decorator dynamoose
+yarn add dynamoose-decorator dynamoose reflect-metadata
 ```
 
 install using `pnpm`
 
 ```bash
-pnpm add dynamoose-decorator dynamoose
+pnpm add dynamoose-decorator dynamoose reflect-metadata
 ```
 
-and then modify the tsconfig.json
+⚠️ **Note:** `reflect-metadata` is required as a peer dependency. Make sure it's installed in your project.
+
+Modify your `tsconfig.json` to enable decorator support:
+
 ```json
 {
   "compilerOptions": {

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "README.md"
   ],
   "scripts": {
-    "build": "esbuild ./src/index.ts --external:dynamoose --bundle --minify --platform=node --outfile=./dist/src/index.js --sourcemap && tsc --emitDeclarationOnly --outDir dist",
+    "build": "esbuild ./src/index.ts --external:dynamoose --external:reflect-metadata --bundle --minify --platform=node --outfile=./dist/src/index.js --sourcemap && tsc --emitDeclarationOnly --outDir dist",
     "test": "jest",
     "lint:ts": "tsc --noEmit",
     "lint:prettier": "prettier . --check",
@@ -38,7 +38,8 @@
     "typescript": "^5.3.3"
   },
   "peerDependencies": {
-    "dynamoose": "^3.2.1"
+    "dynamoose": "^3.2.1",
+    "reflect-metadata": "^0.2.1"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Fixes reflect-metadata conflicts with NestJS by externalizing it from the bundle instead of bundling inline.

## Changes

- Add `--external:reflect-metadata` to esbuild command
- Move `reflect-metadata` to `peerDependencies`
- Update README with installation instructions